### PR TITLE
refactor: replace polling with backend event for analysis updates

### DIFF
--- a/packages/frontend/src/types.ts
+++ b/packages/frontend/src/types.ts
@@ -18,6 +18,10 @@ export interface FrontendSDK {
     setCspCheckSettings: (settings: Record<string, boolean>) => Promise<void>;
     updateCspCheckSetting: (checkId: string, enabled: boolean) => Promise<void>;
     getBypassDatabase: () => Promise<BypassEntry[]>;
+    onEvent: (
+      event: "analysisUpdated",
+      callback: () => void,
+    ) => { stop: () => void };
   };
 }
 


### PR DESCRIPTION
# replace polling with backend event for analysis updates

**Key Changes:**

- [ ] Replace frontend polling mechanism with Caido SDK event-based updates for CSP analysis state changes.
- [ ] Backend now emits `analysisUpdated` event when analysis completes or cache clears. 
- [ ] Frontend subscribes to this event instead of polling every 5 seconds, providing instant updates with reduced API calls.

  - Use `sdk.api.send()` to emit events from backend
  - Use `sdk.backend.onEvent()` to subscribe in frontend
  - Remove polling interval and related timing logic

**Changed:**

  - Use `sdk.api.send()` to emit events from backend
  - Use `sdk.backend.onEvent()` to subscribe in frontend
  - Remove polling interval and related timing logic

**Removed:**

- [ ] polling


---

## Generated Summary

- Integrated "analysisUpdated" event handling across backend and frontend.
- Updated backend SDK type signatures to include both API and Events, and trigger "analysisUpdated" after cache clearing and CSP analysis.
- Extended the frontend SDK interface to support event subscriptions for "analysisUpdated".
- Replaced the timer-based auto-refresh in the frontend with an event-driven mechanism that refreshes the dashboard on analysis updates.
- Added proper subscription cleanup on component unmount to prevent memory leaks.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)


<!-- Delete any sections that are not applicable -->
<!-- Add screenshots or code examples if relevant -->
