### PR TITLE
chore: add dependency release age guardrails

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
     ":automergeBranch"
   ],
   "dependencyDashboardTitle": "Renovate Dashboard 🤖",
+  "minimumReleaseAge": "3 days",
   "suppressNotifications": [
     "prIgnoreNotification"
   ],

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=3
+ignore-scripts=true


### PR DESCRIPTION
Summary:
- add a repo-local npm release-age cooldown via .npmrc
- add Renovate minimumReleaseAge set to 3 days

Testing:
- not run (config-only change)